### PR TITLE
Use -static for full static compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,8 +36,12 @@ include_directories ("${PROJECT_BINARY_DIR}")
 
 add_executable (tini src/tini.c)
 
+add_executable (tini-static src/tini.c)
+set_target_properties (tini-static PROPERTIES LINK_FLAGS "-Wl,--no-export-dynamic -static")
+
 # Installation
 install (TARGETS tini DESTINATION bin)
+install (TARGETS tini-static DESTINATION bin)
 
 # Packaging
 include (InstallRequiredSystemLibraries)

--- a/README.md
+++ b/README.md
@@ -63,10 +63,21 @@ Assuming your entrypoint was `/docker-entrypoint.sh`, then you would use:
     ENTRYPOINT ["/tini", "--", "/docker-entrypoint.sh"]
 
 
+### Statically-Linked Version ###
+
+Tini has very few dependencies (it only depends on libc), but if your
+container fails to start, you might want to consider using the statically-built
+version instead:
+
+    ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-static /tini
+
+
 ### Size Considerations ###
 
 Tini is a very small file (in the 10KB range), so it doesn't add much weight
 to your container.
+
+The statically-linked version is bigger, but still < 1M.
 
 
 ### Building Tini ###

--- a/ci/run_build.sh
+++ b/ci/run_build.sh
@@ -22,26 +22,27 @@ make package
 popd
 
 # Smoke tests (actual tests need Docker to run; they don't run within the CI environment)
-tini="${BUILD_DIR}/tini"
-echo "Testing $tini with: true"
-$tini -vvvv true
+for tini in "${BUILD_DIR}/tini" "${BUILD_DIR}/tini-static"; do
+  echo "Testing $tini with: true"
+  $tini -vvvv true
 
-echo "Testing $tini with: false"
-if $tini -vvvv false; then
-  exit 1
-fi
+  echo "Testing $tini with: false"
+  if $tini -vvvv false; then
+    exit 1
+  fi
 
-# Place files
-mkdir -p "${DIST_DIR}"
-cp "${BUILD_DIR}"/tini{,*.rpm,*deb} "${DIST_DIR}"
+  # Place files
+  mkdir -p "${DIST_DIR}"
+  cp "${BUILD_DIR}"/tini{,*.rpm,*deb} "${DIST_DIR}"
 
-# Quick audit
-if which rpm; then
-  echo "Contents for RPM:"
-  rpm -qlp "${DIST_DIR}/tini"*.rpm
-fi
+  # Quick audit
+  if which rpm; then
+    echo "Contents for RPM:"
+    rpm -qlp "${DIST_DIR}/tini"*.rpm
+  fi
 
-if which dpkg; then
-  echo "Contents for DEB:"
-  dpkg --contents "${DIST_DIR}/tini"*deb
-fi
+  if which dpkg; then
+    echo "Contents for DEB:"
+    dpkg --contents "${DIST_DIR}/tini"*deb
+  fi
+done

--- a/test/test.py
+++ b/test/test.py
@@ -73,7 +73,7 @@ if __name__ == "__main__":
 
 
     # Funtional tests
-    for entrypoint in ["/tini/dist/tini"]:
+    for entrypoint in ["/tini/dist/tini", "/tini/dist/tini-static"]:
         functional_base_cmd = base_cmd + [
             "--entrypoint={0}".format(entrypoint),
             img,


### PR DESCRIPTION
This allows the use of `tini` within even more minimal environments (such as images that are `FROM scratch` with a single application binary `COPY`'d in).

This is just a proposal, so I'm definitely willing to debate and/or update and/or close, but I think this is worth discussing. :smile: