### PR TITLE
Fix 22

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,8 @@ deploy:
   file:
     - "./dist/tini"
     - "./dist/tini-static"
-    - "./dist/tini_0.8.2.deb"
-    - "./dist/tini_0.8.2.rpm"
+    - "./dist/tini_0.8.3.deb"
+    - "./dist/tini_0.8.3.rpm"
   on:
     repo: krallin/tini
     tags: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project (tini C)
 # Config
 set (tini_VERSION_MAJOR 0)
 set (tini_VERSION_MINOR 8)
-set (tini_VERSION_PATCH 2)
+set (tini_VERSION_PATCH 3)
 
 # Extract git version and dirty-ness
 execute_process (

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,22 @@ else()
 endif()
 
 # Flags
-add_definitions (-D_FORTIFY_SOURCE=2)
+include(CheckCSourceCompiles)
+
+check_c_source_compiles("
+#ifndef _FORTIFY_SOURCE
+#error \"Not defined: _FORTIFY_SOURCE\"
+#endif
+int main(void)                                                                                                              {
+  return 0;
+}
+" HAS_BUILTIN_FORTIFY)
+
+# Flags
+if(NOT HAS_BUILTIN_FORTIFY)
+	add_definitions(-D_FORTIFY_SOURCE=2)
+endif()
+
 set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99 -Werror -Wextra -Wall -pedantic-errors -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat")
 set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-Bsymbolic-functions -Wl,-z,relro -Wl,-s")
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ In Docker, you will want to use an entrypoint so you don't have to remember
 to manually invoke Tini:
 
     # Add Tini
-    ENV TINI_VERSION v0.8.2
+    ENV TINI_VERSION v0.8.3
     ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
     RUN chmod +x /tini
     ENTRYPOINT ["/tini", "--"]


### PR DESCRIPTION
Ensure builds work on Alpine Linux despite `_FORTIFY_SOURCE` being a builtin there and erroring on warnings.