### PR TITLE
Add tests for hardening in CI script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ addons:
     - libcap-dev
     - python-pip
     - python-virtualenv
+    - hardening-includes
 
 script: ./ci/run_build.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:precise
 
 RUN apt-get update \
- && apt-get install --no-install-recommends --yes build-essential git gdb valgrind cmake rpm python-dev libcap-dev python-pip python-virtualenv \
+ && apt-get install --no-install-recommends --yes build-essential git gdb valgrind cmake rpm python-dev libcap-dev python-pip python-virtualenv hardening-includes \
  && rm -rf /var/lib/apt/lists/*
 
 # Pre-install those here for faster local builds.

--- a/tpl/travis.yml.tpl
+++ b/tpl/travis.yml.tpl
@@ -22,6 +22,7 @@ addons:
     - libcap-dev
     - python-pip
     - python-virtualenv
+    - hardening-includes
 
 script: ./ci/run_build.sh
 


### PR DESCRIPTION
This ensures that `_FORTIFY_SOURCE` is used in the build using `hardening-check` (also updates the tests to be more robust).