### PR TITLE
Build: ensure the correct git directory is used

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,8 @@ deploy:
   file:
     - "./dist/tini"
     - "./dist/tini-static"
-    - "./dist/tini_0.8.3.deb"
-    - "./dist/tini_0.8.3.rpm"
+    - "./dist/tini_0.8.4.deb"
+    - "./dist/tini_0.8.4.rpm"
   on:
     repo: krallin/tini
     tags: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,14 +8,14 @@ set (tini_VERSION_PATCH 3)
 
 # Extract git version and dirty-ness
 execute_process (
-  COMMAND git log -n 1 --date=local --pretty=format:%h
+  COMMAND git --git-dir "${PROJECT_SOURCE_DIR}/.git" --work-tree "${PROJECT_SOURCE_DIR}" log -n 1 --date=local --pretty=format:%h
   WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
   RESULT_VARIABLE git_version_check_ret
   OUTPUT_VARIABLE tini_VERSION_GIT
 )
 
 execute_process(
-  COMMAND git status --porcelain --untracked-files=no
+  COMMAND git --git-dir "${PROJECT_SOURCE_DIR}/.git" --work-tree "${PROJECT_SOURCE_DIR}" status --porcelain --untracked-files=no
   WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
   OUTPUT_VARIABLE git_dirty_check_out
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project (tini C)
 # Config
 set (tini_VERSION_MAJOR 0)
 set (tini_VERSION_MINOR 8)
-set (tini_VERSION_PATCH 3)
+set (tini_VERSION_PATCH 4)
 
 # Extract git version and dirty-ness
 execute_process (

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ In Docker, you will want to use an entrypoint so you don't have to remember
 to manually invoke Tini:
 
     # Add Tini
-    ENV TINI_VERSION v0.8.3
+    ENV TINI_VERSION v0.8.4
     ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
     RUN chmod +x /tini
     ENTRYPOINT ["/tini", "--"]


### PR DESCRIPTION
If Tini is built without its own .git directory, but within another
git directory (i.e. the tarball was extracted in a directory
that happens to be a git tree), then we end up with the wrong
git version in `tini -h`.

This actually happens in the Alpine builds (e.g. Tini 0.8.3 in
Alpine has git hash d89e144, which is a Aports commit hash, not
a Tini commit hash:

https://github.com/alpinelinux/aports/commit/d89e144

This patch forces git to use the current git directory, or to not
use one at all (which is fine, since in that case Tini is
presumably being built from a release tarball).