### PR TITLE
Update README to point to Alpine CDN repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ your package manager):
 On Alpine Linux, you can use the following command to install Tini (currently
 available in `edge`):
 
-    apk add --update --repository http://dl-1.alpinelinux.org/alpine/edge/community/ tini
+    apk add --update --repository http://dl-cdn.alpinelinux.org/alpine/edge/community/ tini
 
 
 ### NixOS ###


### PR DESCRIPTION
I ran into trouble installing `tini` from http://dl-1.alpinelinux.org/alpine/edge/community/

```bash
WARNING: Ignoring APKINDEX.83d1b7a5.tar.gz: No such file or directory
ERROR: unsatisfiable constraints:
  tini (missing):
    required by: world[tini]
The command '/bin/sh -c apk add --repository http://dl-1.alpinelinux.org/alpine/edge/community/ tini' returned a non-zero code: 1
```

Updating to http://dl-1.alpinelinux.org/alpine/edge/community/ seems to fix it. Not sure if that's the right way but it worked for me :)