### PR TITLE
handle return val of fwrite() to pacify compiler warn

### DIFF
--- a/src/tini.c
+++ b/src/tini.c
@@ -208,9 +208,14 @@ void print_usage(char* const name, FILE* const file) {
 }
 
 void print_license(FILE* const file) {
-	fwrite(LICENSE, sizeof(char), LICENSE_len, file);
+    if(LICENSE_len > fwrite(LICENSE, sizeof(char), LICENSE_len, file)) {
+        // Don't handle this error for now, since parse_args won't care
+        // about the return value. We do need to check it to compile with
+        // older glibc, though.
+        // See: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=25509
+        // See: http://sourceware.org/bugzilla/show_bug.cgi?id=11959
+    }
 }
-
 
 int parse_args(const int argc, char* const argv[], char* (**child_args_ptr_ptr)[], int* const parse_fail_exitcode_ptr) {
 	char* name = argv[0];


### PR DESCRIPTION
Getting compiler warnings on gcc 4.4.7:
```
+ make tini-static
Scanning dependencies of target tini-static
[100%] Building C object CMakeFiles/tini-static.dir/src/tini.c.o
cc1: warnings being treated as errors
/go/tini/src/tini.c: In function 'print_license':
/go/tini/src/tini.c:211: error: ignoring return value of 'fwrite', declared with attribute warn_unused_result
make[3]: *** [CMakeFiles/tini-static.dir/src/tini.c.o] Error 1
make[2]: *** [CMakeFiles/tini-static.dir/all] Error 2
make[1]: *** [CMakeFiles/tini-static.dir/rule] Error 2
make: *** [tini-static] Error 2
```

See https://github.com/docker/docker/issues/28273 for background.

For reference:
```
# gcc --version
gcc (GCC) 4.4.7 20120313 (Red Hat 4.4.7-17)
```