### PR TITLE
Support ENXIO on lx-branded zones

### DIFF
--- a/src/tini.c
+++ b/src/tini.c
@@ -116,6 +116,9 @@ int isolate_child() {
 	if (tcsetpgrp(STDIN_FILENO, getpgrp())) {
 		if (errno == ENOTTY) {
 			PRINT_DEBUG("tcsetpgrp failed: no tty (ok to proceed)")
+		} else if (errno == ENXIO) {
+			// can occur on lx-branded zones
+			PRINT_DEBUG("tcsetpgrp failed: no such device (ok to proceed");
 		} else {
 			PRINT_FATAL("tcsetpgrp failed: %s", strerror(errno));
 			return 1;


### PR DESCRIPTION
Related to https://github.com/joyent/sdc-docker/issues/91

ENXIO is returned on illumos by [`ioctl`](https://illumos.org/man/2/ioctl), which gets called by [`tcsetgrp`](https://github.com/joyent/illumos-joyent/blob/master/usr/src/lib/libc/port/gen/tcsetpgrp.c#L44). This occurs when using tini inside a docker container running on lx-branded zones on illumos. 

Here are a couple of docker images to help prove this out:
Before fix: d0cker/test-dtrace:1.1.1
After fix: d0cker/test-dtrace:1.1.2

With d0cker/test-dtrace:1.1.1 image:
```
[INFO  tini (1)] Spawned child process 'node' with pid '52187'
[FATAL tini (52187)] tcsetpgrp failed: No such device or address
[DEBUG tini (1)] Received SIGCHLD
[DEBUG tini (1)] Reaped child with pid: '52187'
[INFO  tini (1)] Main child exited normally (with status '1')
[TRACE tini (1)] No child to wait
[TRACE tini (1)] Exiting: child has exited
```

With d0cker/test-dtrace:1.1.2 image:
```
[INFO  tini (1)] Spawned child process 'node' with pid '28463'
[DEBUG tini (28463)] gpid: 27999
Listening at http://localhost:8080
```