### PR TITLE
Fix PR_SET_CHILD_SUBREAPER call

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project (tini C)
 # Config
 set (tini_VERSION_MAJOR 0)
 set (tini_VERSION_MINOR 13)
-set (tini_VERSION_PATCH 1)
+set (tini_VERSION_PATCH 2)
 
 # Build options
 option(MINIMAL "Disable argument parsing and verbose output" OFF)

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ In Docker, you will want to use an entrypoint so you don't have to remember
 to manually invoke Tini:
 
     # Add Tini
-    ENV TINI_VERSION v0.13.1
+    ENV TINI_VERSION v0.13.2
     ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
     RUN chmod +x /tini
     ENTRYPOINT ["/tini", "--"]
@@ -63,7 +63,7 @@ The `tini` and `tini-static` binaries are signed using the key `595E85A6B1B4779E
 You can verify their signatures using `gpg` (which you may install using
 your package manager):
 
-    ENV TINI_VERSION v0.13.1
+    ENV TINI_VERSION v0.13.2
     ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
     ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini.asc /tini.asc
     RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 \

--- a/src/tini.c
+++ b/src/tini.c
@@ -306,7 +306,7 @@ int parse_env() {
 #if HAS_SUBREAPER
 int register_subreaper () {
 	if (subreaper > 0) {
-		if (prctl(PR_SET_CHILD_SUBREAPER)) {
+		if (prctl(PR_SET_CHILD_SUBREAPER, 1)) {
 			if (errno == EINVAL) {
 				PRINT_FATAL("PR_SET_CHILD_SUBREAPER is unavailable on this platform. Are you using Linux >= 3.4?")
 			} else {


### PR DESCRIPTION
PR_SET_CHILD_SUBREAPER actually requires a non-zero argument to `prctl`
in order to work..!

Now, this used to work just fine (and currently works in most places)
because when we use a libc that doesn't know about
PR_SET_CHILD_SUBREAPER, it doesn't do anything about the second argument
passed to `pctrl`, so we end up sending some junk in as the second
argument. What we send appears to be completely random and as such seems
very unlikely to be zero, and so things appear to work (e.g. the tests
all pass, etc.).

However, using a libc that does know about this argument (e.g. Ubuntu
Xenial), things *don't* work because the second argument is
automatically set to 0 when we don't provide one.

This probably went unnoticed for a while considering that `tini-static`
isn't affected (it's built on Trusty), and that this mode isn't enabled
by default in the first place.