### PR TITLE
fix C conformance

### DIFF
--- a/src/tini.c
+++ b/src/tini.c
@@ -156,7 +156,7 @@ int spawn(const signal_configuration_t* const sigconf_ptr, char* const argv[], i
 		// and exit with the correct return status for the error that we encountered
 		// See: http://www.tldp.org/LDP/abs/html/exitcodes.html#EXITCODESREF
 		int status = 1;
-		switch errno {
+		switch (errno) {
 			case ENOENT:
 				status = 127;
 				break;


### PR DESCRIPTION
Someone has been writing too much Go recently.  This works because
`errno` is typically a macro coming with its own set of parens.