### PR TITLE
Add -e flag to a expect a given exit code

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,22 @@ as PID 1.
 and isn't registered as a subreaper. If you don't see a warning, you're fine.*
 
 
+### Remapping exit codes ###
+
+Tini will reuse the child's exit code when exiting, but occasionally, this may
+not be exactly what you want (e.g. if your child exits with 143 after receiving
+SIGTERM). Notably, this can be an issue with Java apps.
+
+In this case, you can use the `-e` flag to remap an arbitrary exit code to 0.
+You can pass the flag multiple times if needed.
+
+For example:
+
+```
+tini -e 143 -- ...
+```
+
+
 ### Process group killing ###
 
 By default, Tini only kills its immediate child process.  This can be

--- a/ci/run_build.sh
+++ b/ci/run_build.sh
@@ -37,6 +37,7 @@ fi
 
 echo "CC=${CC}"
 echo "CFLAGS=${CFLAGS}"
+echo "MINIMAL=${MINIMAL-}"
 echo "ARCH_SUFFIX=${ARCH_SUFFIX-}"
 echo "ARCH_NATIVE=${ARCH_NATIVE-}"
 
@@ -63,7 +64,6 @@ fi
 popd
 
 pkg_version="$(cat "${BUILD_DIR}/VERSION")"
-
 
 if [[ -n "${ARCH_NATIVE-}" ]]; then
   echo "Built native package (ARCH_NATIVE=${ARCH_NATIVE-})"

--- a/tpl/README.md.in
+++ b/tpl/README.md.in
@@ -141,6 +141,22 @@ as PID 1.
 and isn't registered as a subreaper. If you don't see a warning, you're fine.*
 
 
+### Remapping exit codes ###
+
+Tini will reuse the child's exit code when exiting, but occasionally, this may
+not be exactly what you want (e.g. if your child exits with 143 after receiving
+SIGTERM). Notably, this can be an issue with Java apps.
+
+In this case, you can use the `-e` flag to remap an arbitrary exit code to 0.
+You can pass the flag multiple times if needed.
+
+For example:
+
+```
+tini -e 143 -- ...
+```
+
+
 ### Process group killing ###
 
 By default, Tini only kills its immediate child process.  This can be


### PR DESCRIPTION
Passing this flag causes Tini to remap the given exit code to 0 when
forwarding it.

Fixes: #69 

FYI, @nixx