### PR TITLE
Make Alpine instructions Dockerfile commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,9 @@ your package manager):
 
 On Alpine Linux, you can use the following command to install Tini:
 
-    apk add --update tini
+    RUN apk add --update tini
     # Tini is now available at /sbin/tini
+    ENTRYPOINT ["/sbin/tini", "--"]
 
 
 ### NixOS ###

--- a/tpl/README.md.in
+++ b/tpl/README.md.in
@@ -92,8 +92,9 @@ your package manager):
 
 On Alpine Linux, you can use the following command to install Tini:
 
-    apk add --update tini
+    RUN apk add --update tini
     # Tini is now available at /sbin/tini
+    ENTRYPOINT ["/sbin/tini", "--"]
 
 
 ### NixOS ###


### PR DESCRIPTION
I thought it'd be a little more clear if the instructions for Alpine were Dockerfile commands like in the "Using Tini" section.