### PR TITLE
Allow setting VERSION_GIT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,34 +6,44 @@ set (tini_VERSION_MAJOR 0)
 set (tini_VERSION_MINOR 14)
 set (tini_VERSION_PATCH 0)
 
+set (GIT_PREFIX " - git.")
+
 # Build options
 option(MINIMAL "Disable argument parsing and verbose output" OFF)
+
+# Set VERSION_GIT to INTERNAL so it does not persist across runs of CMake, just
+# like the auto-discovery would.
+set(VERSION_GIT "" CACHE INTERNAL "Override the git revision")
 
 if(MINIMAL)
 	add_definitions(-DTINI_MINIMAL=1)
 endif()
 
 # Extract git version and dirty-ness
-execute_process (
-  COMMAND git --git-dir "${PROJECT_SOURCE_DIR}/.git" --work-tree "${PROJECT_SOURCE_DIR}" log -n 1 --date=local --pretty=format:%h
-  WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
-  RESULT_VARIABLE git_version_check_ret
-  OUTPUT_VARIABLE tini_VERSION_GIT
-)
-
-execute_process(
-  COMMAND git --git-dir "${PROJECT_SOURCE_DIR}/.git" --work-tree "${PROJECT_SOURCE_DIR}" status --porcelain --untracked-files=no
-  WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
-  OUTPUT_VARIABLE git_dirty_check_out
-)
-
-if("${git_version_check_ret}" EQUAL 0)
-  set(tini_VERSION_GIT " - git.${tini_VERSION_GIT}")
-  if(NOT "${git_dirty_check_out}" STREQUAL "")
-    set(tini_VERSION_GIT "${tini_VERSION_GIT}-dirty")
-  endif()
+if(VERSION_GIT)
+	set(tini_VERSION_GIT "${GIT_PREFIX}${VERSION_GIT}")
 else()
-  set(tini_VERSION_GIT "")
+	execute_process (
+	  COMMAND git --git-dir "${PROJECT_SOURCE_DIR}/.git" --work-tree "${PROJECT_SOURCE_DIR}" log -n 1 --date=local --pretty=format:%h
+	  WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
+	  RESULT_VARIABLE git_version_check_ret
+	  OUTPUT_VARIABLE tini_VERSION_GIT
+	)
+
+	execute_process(
+	  COMMAND git --git-dir "${PROJECT_SOURCE_DIR}/.git" --work-tree "${PROJECT_SOURCE_DIR}" status --porcelain --untracked-files=no
+	  WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
+	  OUTPUT_VARIABLE git_dirty_check_out
+	)
+
+	if("${git_version_check_ret}" EQUAL 0)
+		set(tini_VERSION_GIT "${GIT_PREFIX}${tini_VERSION_GIT}")
+		if(NOT "${git_dirty_check_out}" STREQUAL "")
+			set(tini_VERSION_GIT "${tini_VERSION_GIT}-dirty")
+		endif()
+	else()
+		set(tini_VERSION_GIT "")
+	endif()
 endif()
 
 # Flags


### PR DESCRIPTION
Fixes: #79 

@ncopa, will this work for you? (I altered your suggestion a little bit to avoid using `TINI` as a prefix for a configuration variable in Tini's Cmake script, and skipped the entire auto-discovery if the override is set)

You should just need to set `VERSION_GIT ` to the "short" hash, i.e. the first 7 characters (note: I guess you could get an inconsistency if there is a collision between commit IDs on the first 7 characters that would cause git to extend the auto-generated ref... but TBH that's probably unlikely enough that you don't need to care).