### PR TITLE
Use --no-cache for Alpine to minimize footprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ your package manager):
 
 On Alpine Linux, you can use the following command to install Tini:
 
-    RUN apk add --update tini
+    RUN apk add --no-cache tini
     # Tini is now available at /sbin/tini
     ENTRYPOINT ["/sbin/tini", "--"]
 

--- a/tpl/README.md.in
+++ b/tpl/README.md.in
@@ -96,7 +96,7 @@ your package manager):
 
 On Alpine Linux, you can use the following command to install Tini:
 
-    RUN apk add --update tini
+    RUN apk add --no-cache tini
     # Tini is now available at /sbin/tini
     ENTRYPOINT ["/sbin/tini", "--"]
 


### PR DESCRIPTION
Using `apk add --no-cache tini` instead of `apk add --update tini` avoids caching and reduces the size of the resulting container. See here: https://github.com/gliderlabs/docker-alpine/blob/master/docs/usage.md#disabling-cache