### PR TITLE
Build musl-based binaries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,12 @@ language: generic
 
 env:
   matrix:
+    - CC=gcc ARCH_SUFFIX= ARCH_NATIVE=1 MINIMAL=
     - CC=gcc ARCH_SUFFIX=amd64 ARCH_NATIVE=1 MINIMAL=
     - CC=arm-linux-gnueabihf-gcc ARCH_SUFFIX=armhf ARCH_NATIVE= MINIMAL=
     - CC=aarch64-linux-gnu-gcc ARCH_SUFFIX=arm64 ARCH_NATIVE= MINIMAL=
     - CFLAGS="-m32" ARCH_SUFFIX=i386 ARCH_NATIVE= MINIMAL=
+    - CC=musl-gcc ARCH_SUFFIX=muslc-amd64 ARCH_NATIVE=1 MINIMAL=
     - CC=gcc ARCH_SUFFIX=amd64 ARCH_NATIVE=1 MINIMAL=1
   global:
     - SIGN_BINARIES=1

--- a/ci/install_deps.sh
+++ b/ci/install_deps.sh
@@ -9,7 +9,7 @@ DEPS=(
   hardening-includes gnupg
 )
 
-if [[ "$ARCH_SUFFIX" = "amd64" ]]; then
+if [[ -z "${ARCH_SUFFIX-}" ]] || [[ "$ARCH_SUFFIX" = "amd64" ]]; then
   true
 elif [[ "$ARCH_SUFFIX" = "armhf" ]]; then
   DEPS+=(gcc-arm-linux-gnueabihf binutils-arm-linux-gnueabi libc6-dev-armhf-cross)
@@ -17,6 +17,8 @@ elif [[ "$ARCH_SUFFIX" = "arm64" ]]; then
   DEPS+=(gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu libc6-dev-arm64-cross)
 elif [[ "$ARCH_SUFFIX" = "i386" ]]; then
   DEPS+=(libc6-dev-i386  gcc-multilib)
+elif [[ "$ARCH_SUFFIX" = "muslc-amd64" ]]; then
+  DEPS+=(musl-tools)
 else
   echo "Unknown ARCH_SUFFIX=${ARCH_SUFFIX}"
   exit 1

--- a/test/run_inner_tests.py
+++ b/test/run_inner_tests.py
@@ -61,12 +61,13 @@ def main():
 
 
         # Run the signals test
-        for signum in [signal.SIGINT, signal.SIGTERM]:
-            print "running signal test for: {0} ({1} with env {2})".format(SIGNUM_TO_SIGNAME[signum], " ".join(target), env)
+        for signum in [signal.SIGTERM, signal.SIGUSR1, signal.SIGUSR2]:
+            print "running signal test for: {0} ({1} with env {2})".format(signum, " ".join(target), env)
             p = subprocess.Popen(target + [os.path.join(src, "test", "signals", "test.py")], env=dict(os.environ, **env))
+            busy_wait(lambda: len(psutil.Process(p.pid).children(recursive=True)) > 1, 10)
             p.send_signal(signum)
             ret = p.wait()
-            assert ret == -signum, "Signals test failed (ret was {0}, expected {1})".format(ret, -signum)
+            assert ret == 128 + signum, "Signals test failed (ret was {0}, expected {1})".format(ret, 128 + signum)
 
 
     # Run the process group test

--- a/test/run_outer_tests.py
+++ b/test/run_outer_tests.py
@@ -47,17 +47,17 @@ class Command(object):
         # Checks
         if thread.is_alive():
             subprocess.check_call(self.fail_cmd, **pipe_kwargs)
-            err =  Exception("Test failed with timeout!")
+            err = Exception("Test failed with timeout!")
 
         elif self.proc.returncode != retcode:
-            err =  Exception("Test failed with unexpected returncode (expected {0}, got {1})".format(retcode, self.proc.returncode))
+            err = Exception("Test failed with unexpected returncode (expected {0}, got {1})".format(retcode, self.proc.returncode))
 
         if err is not None:
             print "FAIL"
             print "--- STDOUT ---"
-            print self.stdout
+            print getattr(self, "stdout", "no stdout")
             print "--- STDERR ---"
-            print self.stderr
+            print getattr(self, "stderr", "no stderr")
             print "--- ... ---"
             raise err
         else:
@@ -146,7 +146,7 @@ def main():
         Command(functional_base_cmd + ["/tini/test/reaping/stage_1.py"], fail_cmd).run(timeout=10)
 
         # Signals test
-        for sig, retcode in [("INT", 1), ("TERM", 143)]:
+        for sig, retcode in [("TERM", 143), ("USR1", 138), ("USR2", 140)]:
             Command(
                 functional_base_cmd + ["/tini/test/signals/test.py"],
                 fail_cmd,

--- a/test/signals/test.py
+++ b/test/signals/test.py
@@ -1,6 +1,13 @@
 #!/usr/bin/env python
-import time
+import signal
+import os
+
+
+def main():
+    signal.signal(signal.SIGTERM, signal.SIG_DFL)
+    signal.signal(signal.SIGUSR1, signal.SIG_DFL)
+    signal.signal(signal.SIGUSR2, signal.SIG_DFL)
+    os.system("sleep 100")
 
 if __name__ == "__main__":
-    while 1:
-        time.sleep(10)
+    main()


### PR DESCRIPTION
Also fixed a bug with the signals test, which didn't properly exercise
Tini: rather than check that Tini was properly exiting with 128 +
signal, it raced against Tini and was only successful if Tini didn't get
the change to spawn a subprocess!

Fixes #91 