### PR TITLE
Add support for armel (ARMv5), ppc64el (IBM POWER 8), and s390x (IBM z Systems)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,16 +6,16 @@ language: generic
 
 env:
   matrix:
-    - CC=gcc ARCH_SUFFIX= ARCH_NATIVE=1 MINIMAL=
-    - CC=gcc ARCH_SUFFIX=amd64 ARCH_NATIVE=1 MINIMAL=
-    - CC=arm-linux-gnueabi-gcc ARCH_SUFFIX=armel ARCH_NATIVE= MINIMAL=
-    - CC=arm-linux-gnueabihf-gcc ARCH_SUFFIX=armhf ARCH_NATIVE= MINIMAL=
-    - CC=aarch64-linux-gnu-gcc ARCH_SUFFIX=arm64 ARCH_NATIVE= MINIMAL=
-    - CFLAGS="-m32" ARCH_SUFFIX=i386 ARCH_NATIVE= MINIMAL=
-    - CC=powerpc64le-linux-gnu-gcc ARCH_SUFFIX=ppc64el ARCH_NATIVE= MINIMAL=
-    - CC=s390x-linux-gnu-gcc ARCH_SUFFIX=s390x ARCH_NATIVE= MINIMAL=
-    - CC=musl-gcc ARCH_SUFFIX=muslc-amd64 ARCH_NATIVE=1 MINIMAL=
-    - CC=gcc ARCH_SUFFIX=amd64 ARCH_NATIVE=1 MINIMAL=1
+    - ARCH_SUFFIX= CC=gcc ARCH_NATIVE=1 MINIMAL=
+    - ARCH_SUFFIX=amd64 CC=gcc ARCH_NATIVE=1 MINIMAL=
+    - ARCH_SUFFIX=amd64 CC=gcc ARCH_NATIVE=1 MINIMAL=1
+    - ARCH_SUFFIX=arm64 CC=aarch64-linux-gnu-gcc ARCH_NATIVE= MINIMAL=
+    - ARCH_SUFFIX=armel CC=arm-linux-gnueabi-gcc ARCH_NATIVE= MINIMAL=
+    - ARCH_SUFFIX=armhf CC=arm-linux-gnueabihf-gcc ARCH_NATIVE= MINIMAL=
+    - ARCH_SUFFIX=i386 CFLAGS="-m32" ARCH_NATIVE= MINIMAL=
+    - ARCH_SUFFIX=muslc-amd64 CC=musl-gcc ARCH_NATIVE=1 MINIMAL=
+    - ARCH_SUFFIX=ppc64el CC=powerpc64le-linux-gnu-gcc ARCH_NATIVE= MINIMAL=
+    - ARCH_SUFFIX=s390x CC=s390x-linux-gnu-gcc ARCH_NATIVE= MINIMAL=
   global:
     - secure: "RKF9Z9gLxp6k/xITqn7ma1E9HfpYcDXuJFf4862WeH9EMnK9lDq+TWnGsQfkIlqh8h9goe7U+BvRiTibj9MiD5u7eluLo3dlwsLxPpYtyswYeLeC1wKKdT5LPGAXbRKomvBalRYMI+dDnGIM4w96mHgGGvx2zZXGkiAQhm6fJ3k="
     - DIST_DIR="${PWD}/dist"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: required
-dist: trusty
+services:
+  - docker
 
 language: generic
 
@@ -7,22 +8,23 @@ env:
   matrix:
     - CC=gcc ARCH_SUFFIX= ARCH_NATIVE=1 MINIMAL=
     - CC=gcc ARCH_SUFFIX=amd64 ARCH_NATIVE=1 MINIMAL=
+    - CC=arm-linux-gnueabi-gcc ARCH_SUFFIX=armel ARCH_NATIVE= MINIMAL=
     - CC=arm-linux-gnueabihf-gcc ARCH_SUFFIX=armhf ARCH_NATIVE= MINIMAL=
     - CC=aarch64-linux-gnu-gcc ARCH_SUFFIX=arm64 ARCH_NATIVE= MINIMAL=
     - CFLAGS="-m32" ARCH_SUFFIX=i386 ARCH_NATIVE= MINIMAL=
+    - CC=powerpc64le-linux-gnu-gcc ARCH_SUFFIX=ppc64el ARCH_NATIVE= MINIMAL=
+    - CC=s390x-linux-gnu-gcc ARCH_SUFFIX=s390x ARCH_NATIVE= MINIMAL=
     - CC=musl-gcc ARCH_SUFFIX=muslc-amd64 ARCH_NATIVE=1 MINIMAL=
     - CC=gcc ARCH_SUFFIX=amd64 ARCH_NATIVE=1 MINIMAL=1
   global:
-    - SIGN_BINARIES=1
     - secure: "RKF9Z9gLxp6k/xITqn7ma1E9HfpYcDXuJFf4862WeH9EMnK9lDq+TWnGsQfkIlqh8h9goe7U+BvRiTibj9MiD5u7eluLo3dlwsLxPpYtyswYeLeC1wKKdT5LPGAXbRKomvBalRYMI+dDnGIM4w96mHgGGvx2zZXGkiAQhm6fJ3k="
-    - DIST_DIR="${HOME}/up"
+    - DIST_DIR="${PWD}/dist"
 
 before_install:
   - openssl aes-256-cbc -K $encrypted_2893fd5649e7_key -iv $encrypted_2893fd5649e7_iv -in sign.key.enc -out sign.key -d || echo "Encrypted signing key unavailable"
 
 script:
-  - sudo ./ci/install_deps.sh
-  - ./ci/run_build.sh
+  - ./ddist.sh "$ARCH_SUFFIX"
   - ls -lah "$DIST_DIR"
   - git diff --exit-code
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:trusty
+FROM ubuntu:xenial
 
 ARG ARCH_SUFFIX
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,3 +7,12 @@ RUN /install_deps.sh
 
 # Pre-install those here for faster local builds.
 RUN CFLAGS="-DPR_SET_CHILD_SUBREAPER=36 -DPR_GET_CHILD_SUBREAPER=37" pip install psutil python-prctl bitmap
+
+ARG ARCH_NATIVE
+ARG CC
+
+# Persist ARGs into the image
+
+ENV ARCH_SUFFIX="$ARCH_SUFFIX" \
+    ARCH_NATIVE="$ARCH_NATIVE" \
+    CC="$CC"

--- a/ci/install_deps.sh
+++ b/ci/install_deps.sh
@@ -9,26 +9,17 @@ DEPS=(
   hardening-includes gnupg
 )
 
-if [[ -z "${ARCH_SUFFIX-}" ]] || [[ "$ARCH_SUFFIX" = "amd64" ]]; then
-  true
-elif [[ "$ARCH_SUFFIX" = "armel" ]]; then
-  DEPS+=(gcc-arm-linux-gnueabi binutils-arm-linux-gnueabi libc6-dev-armel-cross)
-elif [[ "$ARCH_SUFFIX" = "armhf" ]]; then
-  DEPS+=(gcc-arm-linux-gnueabihf binutils-arm-linux-gnueabihf libc6-dev-armhf-cross)
-elif [[ "$ARCH_SUFFIX" = "arm64" ]]; then
-  DEPS+=(gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu libc6-dev-arm64-cross)
-elif [[ "$ARCH_SUFFIX" = "ppc64el" ]]; then
-  DEPS+=(gcc-powerpc64le-linux-gnu binutils-powerpc64le-linux-gnu libc6-dev-ppc64el-cross)
-elif [[ "$ARCH_SUFFIX" = "s390x" ]]; then
-  DEPS+=(gcc-s390x-linux-gnu binutils-s390x-linux-gnu libc6-dev-s390x-cross)
-elif [[ "$ARCH_SUFFIX" = "i386" ]]; then
-  DEPS+=(libc6-dev-i386  gcc-multilib)
-elif [[ "$ARCH_SUFFIX" = "muslc-amd64" ]]; then
-  DEPS+=(musl-tools)
-else
-  echo "Unknown ARCH_SUFFIX=${ARCH_SUFFIX}"
-  exit 1
-fi
+case "${ARCH_SUFFIX-}" in
+  amd64|'') ;;
+  arm64) DEPS+=(gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu libc6-dev-arm64-cross) ;;
+  armel) DEPS+=(gcc-arm-linux-gnueabi binutils-arm-linux-gnueabi libc6-dev-armel-cross) ;;
+  armhf) DEPS+=(gcc-arm-linux-gnueabihf binutils-arm-linux-gnueabihf libc6-dev-armhf-cross) ;;
+  i386) DEPS+=(libc6-dev-i386  gcc-multilib) ;;
+  muslc-amd64) DEPS+=(musl-tools) ;;
+  ppc64el) DEPS+=(gcc-powerpc64le-linux-gnu binutils-powerpc64le-linux-gnu libc6-dev-ppc64el-cross) ;;
+  s390x) DEPS+=(gcc-s390x-linux-gnu binutils-s390x-linux-gnu libc6-dev-s390x-cross) ;;
+  *) echo "Unknown ARCH_SUFFIX=${ARCH_SUFFIX-}"; exit 1 ;;
+esac
 
 apt-get update
 apt-get install --no-install-recommends --yes "${DEPS[@]}"

--- a/ci/install_deps.sh
+++ b/ci/install_deps.sh
@@ -4,17 +4,23 @@ set -o nounset
 set -o xtrace
 
 DEPS=(
-  build-essential git gdb valgrind cmake rpm \
-  python-dev libcap-dev python-pip python-virtualenv \
+  build-essential git gdb valgrind cmake rpm file
+  libcap-dev python-dev python-pip python-setuptools
   hardening-includes gnupg
 )
 
 if [[ -z "${ARCH_SUFFIX-}" ]] || [[ "$ARCH_SUFFIX" = "amd64" ]]; then
   true
+elif [[ "$ARCH_SUFFIX" = "armel" ]]; then
+  DEPS+=(gcc-arm-linux-gnueabi binutils-arm-linux-gnueabi libc6-dev-armel-cross)
 elif [[ "$ARCH_SUFFIX" = "armhf" ]]; then
-  DEPS+=(gcc-arm-linux-gnueabihf binutils-arm-linux-gnueabi libc6-dev-armhf-cross)
+  DEPS+=(gcc-arm-linux-gnueabihf binutils-arm-linux-gnueabihf libc6-dev-armhf-cross)
 elif [[ "$ARCH_SUFFIX" = "arm64" ]]; then
   DEPS+=(gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu libc6-dev-arm64-cross)
+elif [[ "$ARCH_SUFFIX" = "ppc64el" ]]; then
+  DEPS+=(gcc-powerpc64le-linux-gnu binutils-powerpc64le-linux-gnu libc6-dev-ppc64el-cross)
+elif [[ "$ARCH_SUFFIX" = "s390x" ]]; then
+  DEPS+=(gcc-s390x-linux-gnu binutils-s390x-linux-gnu libc6-dev-s390x-cross)
 elif [[ "$ARCH_SUFFIX" = "i386" ]]; then
   DEPS+=(libc6-dev-i386  gcc-multilib)
 elif [[ "$ARCH_SUFFIX" = "muslc-amd64" ]]; then
@@ -27,3 +33,5 @@ fi
 apt-get update
 apt-get install --no-install-recommends --yes "${DEPS[@]}"
 rm -rf /var/lib/apt/lists/*
+
+pip install virtualenv

--- a/ddist.sh
+++ b/ddist.sh
@@ -2,35 +2,46 @@
 set -o errexit
 set -o nounset
 
-if [[ "$#" != 1 ]]; then
-  echo "Usage: $0 ARCH_SUFFIX"
-  exit 1
-fi
-suffix="$1"
-
 REL_HERE=$(dirname "${BASH_SOURCE}")
 HERE=$(cd "${REL_HERE}"; pwd)
 
-IMG="tini-build-${suffix}"
-SRC="/tini"
+IMG="tini-build"
+
+if [[ -n "${ARCH_SUFFIX-}" ]]; then
+  IMG="${IMG}_${ARCH_SUFFIX}"
+fi
+
+if [[ -n "${ARCH_NATIVE-}" ]]; then
+  IMG="${IMG}_native"
+fi
+
+if [[ -n "${CC-}" ]]; then
+  IMG="${IMG}_${CC}"
+fi
 
 # Cleanup the build dir
 rm -f "${HERE}/dist"/*
 
 # Create the build image
-docker build --build-arg "ARCH_SUFFIX=${suffix}" -t "${IMG}" .
+echo "build: ${IMG}"
 
-# Run test without subreaper support, don't copy build files here
+docker build \
+  --build-arg "ARCH_SUFFIX=${ARCH_SUFFIX-}" \
+  --build-arg "ARCH_NATIVE=${ARCH_NATIVE-}" \
+  --build-arg "CC=${CC-gcc}" \
+  -t "${IMG}" \
+  .
+
+# Build new Tini
+SRC="/tini"
+
 docker run -it --rm \
   --volume="${HERE}:${SRC}" \
   -e BUILD_DIR=/tmp/tini-build \
   -e SOURCE_DIR="${SRC}" \
-  -e FORCE_SUBREAPER="${FORCE_SUBREAPER:="1"}" \
-  -e GPG_PASSPHRASE="${GPG_PASSPHRASE:=}" \
-  -e CC="${CC:=gcc}" \
+  -e FORCE_SUBREAPER="${FORCE_SUBREAPER-1}" \
+  -e GPG_PASSPHRASE="${GPG_PASSPHRASE-}" \
   -e CFLAGS="${CFLAGS-}" \
-  -e ARCH_NATIVE="${ARCH_NATIVE-}" \
-  -e ARCH_SUFFIX="${suffix}" \
   -e MINIMAL="${MINIMAL-}" \
   -u "$(id -u):$(id -g)" \
   "${IMG}" "${SRC}/ci/run_build.sh"

--- a/ddist.sh
+++ b/ddist.sh
@@ -29,7 +29,8 @@ docker run -it --rm \
   -e GPG_PASSPHRASE="${GPG_PASSPHRASE:=}" \
   -e CC="${CC:=gcc}" \
   -e CFLAGS="${CFLAGS-}" \
-  -e ARCH_NATIVE="${ARCH_NATIVE-1}" \
+  -e ARCH_NATIVE="${ARCH_NATIVE-}" \
   -e ARCH_SUFFIX="${suffix}" \
   -e MINIMAL="${MINIMAL-}" \
+  -u "$(id -u):$(id -g)" \
   "${IMG}" "${SRC}/ci/run_build.sh"


### PR DESCRIPTION
This required updating from Ubuntu Trusty to Xenial for some of the cross compilers, but Travis doesn't support Xenial builders, so this instead converts Travis to use the already-existing `ddist.sh` script for building via Docker.

cc @yosifkit (I'm sure @estesp and some other IBM folks would probably find this interesting/useful as well)

This is along the same lines as https://github.com/docker-library/hello-world/pull/31, which is where we did something similar for the `hello-world` official image's binaries. :smile:

I manually verified most of the combinations that Travis tests on my own local machine, but hopefully Travis will run on this PR and show me whether I've missed anything important! :smile: