### PR TITLE
update readme to fix instructions for gpg

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ your package manager):
     ENV TINI_VERSION v0.18.0
     ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
     ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini.asc /tini.asc
-    RUN gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 \
-     && gpg --verify /tini.asc
+    RUN gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 \
+     && gpg --batch --verify /tini.asc
 
 
 ### Alpine Linux Package ###

--- a/tpl/README.md.in
+++ b/tpl/README.md.in
@@ -88,8 +88,8 @@ your package manager):
     ENV TINI_VERSION v@tini_VERSION_MAJOR@.@tini_VERSION_MINOR@.@tini_VERSION_PATCH@
     ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
     ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini.asc /tini.asc
-    RUN gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 \
-     && gpg --verify /tini.asc
+    RUN gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 \
+     && gpg --batch --verify /tini.asc
 
 
 ### Alpine Linux Package ###


### PR DESCRIPTION
Something changed in recent version of the libraries within openjdk:8-jdk-slim docker image and now the existing steps were failing with erro `gpg: cannot open '/dev/tty': No such device or address`.