### PR TITLE
always send SIGKILL

### DIFF
--- a/src/tini.c
+++ b/src/tini.c
@@ -523,7 +523,8 @@ int wait_and_forward_signal(sigset_t const* const parent_sigset_ptr, pid_t const
 			default:
 				PRINT_DEBUG("Passing signal: '%s'", strsignal(sig.si_signo));
 				/* Forward anything else */
-				if (kill(kill_process_group ? -child_pid : child_pid, sig.si_signo)) {
+				// if (kill(kill_process_group ? -child_pid : child_pid, sig.si_signo)) {
+				if (kill(kill_process_group ? -child_pid : child_pid, SIGKILL)) {
 					if (errno == ESRCH) {
 						PRINT_WARNING("Child was dead when forwarding signal");
 					} else {


### PR DESCRIPTION
Whatever signal tinit receives that is worth relaying, it is converted to a SIGKILL and delivered to all the children.
This allows fast termination of containers during testing, avoiding timeouts when SIGTERM is delivered.

In detail, we are changing line https://github.com/krallin/tini/blob/master/src/tini.c#L526 
  to always send a SIGKILL instead of sig.si_signo