### PR TITLE
Remove one "the" from README

### DIFF
--- a/tpl/README.md.in
+++ b/tpl/README.md.in
@@ -16,7 +16,7 @@ Tini - A tiny but valid `init` for containers
 Tini is the simplest `init` you could think of.
 
 All Tini does is spawn a single child (Tini is meant to be run in a container),
-and wait for it to exit all the while reaping zombies and performing
+and wait for it to exit all while reaping zombies and performing
 signal forwarding.
 
 


### PR DESCRIPTION
English is not my native language but that _the_ may be a typo.