### PR TITLE
Adds OOM Killer

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+# Matches multiple files with brace expansion notation
+# Set default charset
+[*.{js,py}]
+charset = utf-8
+
+[*.c]
+indent_style = tab
+
+# Tab indentation (no size specified)
+[Makefile]
+indent_style = tab

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,11 @@
 dist
 sign.key
 .env
+CMakeFiles
+
+CPackConfig.cmake
+CPackSourceConfig.cmake
+Makefile
+VERSION
+cmake_install.cmake
+tiniConfig.h

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,0 +1,13 @@
+FROM alpine:3.7
+
+RUN apk add --no-cache bash vim alpine-sdk cmake
+
+ADD . /build
+WORKDIR /build
+
+RUN cmake .
+RUN make
+
+RUN gcc leak.c -o leak
+
+CMD ["./tini", "-v", "-v", "-v", "-k", "./leak"]

--- a/leak.c
+++ b/leak.c
@@ -1,0 +1,14 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+int main() {
+	printf("Going to eat your memories!\n");
+
+	while(1) {
+		malloc(200 * sizeof(int));
+		usleep(5);
+	}
+
+	return 0;
+}


### PR DESCRIPTION
Adds a new -k option that when enabled will check the memory limit and usage of the process
via the cgroup. When within 10% of the limit, a SIGINT is sent. This should allow for better
OOM behavior in ECS where applications are not being appropriately killed.