### PR TITLE
add `chmod +x` step to signed download docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ your package manager):
     ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini.asc /tini.asc
     RUN gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 \
      && gpg --batch --verify /tini.asc /tini
+    RUN chmod +x /tini
 
 
 ### Verifying binaries via checksum ###

--- a/tpl/README.md.in
+++ b/tpl/README.md.in
@@ -90,6 +90,7 @@ your package manager):
     ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini.asc /tini.asc
     RUN gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 \
      && gpg --batch --verify /tini.asc /tini
+    RUN chmod +x /tini
 
 
 ### Verifying binaries via checksum ###


### PR DESCRIPTION
I can see how it's inconsistent that I don't also repeat the `ENTRYPOINT`/`CMD` lines, but I somehow managed to only miss the `chmod` when combining the steps.