### PR TITLE
Add option to halt system instead of process exit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM ubuntu:xenial
+FROM ubuntu:focal
+
+ENV DEBIAN_FRONTEND=noninteractive
 
 ARG ARCH_SUFFIX
 

--- a/README.md
+++ b/README.md
@@ -222,6 +222,24 @@ tini -p SIGTERM -- ...
 and use cases.*
 
 
+### System reboot on exit ###
+
+Instead of merely exiting when the child process exists, Tini can invoke
+`reboot(2)` to bring the system down when it would exit. When running as the
+true PID 1 of a kernel, this prevents a kernel panic that occurs when init
+exits. Use the `-R` option to enable this behavior.
+
+This option allows Tini to function as the init process in a VM, for example,
+in [firecracker](https://github.com/firecracker-microvm/firecracker).
+
+Additionally, Tini can invoke `sync(2)` before reboot. The `-S` option enables
+this extra behavior. If `-S` is specified without `-R` it is ignored.
+
+```
+tini -R -S -- ...
+```
+
+
 More
 ----
 

--- a/ci/install_deps.sh
+++ b/ci/install_deps.sh
@@ -6,7 +6,7 @@ set -o xtrace
 DEPS=(
   build-essential git gdb valgrind cmake rpm file
   libcap-dev python3-dev python3-pip python3-setuptools
-  hardening-includes gnupg
+  devscripts gnupg
 )
 
 case "${ARCH_SUFFIX-}" in

--- a/tpl/README.md.in
+++ b/tpl/README.md.in
@@ -222,6 +222,24 @@ tini -p SIGTERM -- ...
 and use cases.*
 
 
+### System reboot on exit ###
+
+Instead of merely exiting when the child process exists, Tini can invoke
+`reboot(2)` to bring the system down when it would exit. When running as the
+true PID 1 of a kernel, this prevents a kernel panic that occurs when init
+exits. Use the `-R` option to enable this behavior.
+
+This option allows Tini to function as the init process in a VM, for example,
+in [firecracker](https://github.com/firecracker-microvm/firecracker).
+
+Additionally, Tini can invoke `sync(2)` before reboot. The `-S` option enables
+this extra behavior. If `-S` is specified without `-R` it is ignored.
+
+```
+tini -R -S -- ...
+```
+
+
 More
 ----
 


### PR DESCRIPTION
The final thing a true init needs to do--or rather not do--that Tini does not support is not exit like a normal process. When running as true init, Tini causes a kernel panic by exiting.

The proposed options make Tini a workable init for a micro VM, instead of just a Linux namespaces container.