### PR TITLE
chore: bump minimum CMake to 2.8.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8.0)
+cmake_minimum_required (VERSION 2.8.12)
 project (tini C)
 
 # Config


### PR DESCRIPTION
This is both the last version supported by current CMake, and the version in use on Enterprise Linux 7.

This solves deprecation warnings today, and future incompatibility with newer CMake.
