### PR TITLE
Support POSIX basename() from musl libc

### DIFF
--- a/src/tini.c
+++ b/src/tini.c
@@ -14,6 +14,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <stdbool.h>
+#include <libgen.h>
 
 #include "tiniConfig.h"
 #include "tiniLicense.h"
@@ -224,14 +225,19 @@ int spawn(const signal_configuration_t* const sigconf_ptr, char* const argv[], i
 }
 
 void print_usage(char* const name, FILE* const file) {
-	fprintf(file, "%s (%s)\n", basename(name), TINI_VERSION_STRING);
+	char *dirc, *bname;
+
+	dirc = strdup(name);
+	bname = basename(dirc);
+
+	fprintf(file, "%s (%s)\n", bname, TINI_VERSION_STRING);
 
 #if TINI_MINIMAL
-	fprintf(file, "Usage: %s PROGRAM [ARGS] | --version\n\n", basename(name));
+	fprintf(file, "Usage: %s PROGRAM [ARGS] | --version\n\n", bname);
 #else
-	fprintf(file, "Usage: %s [OPTIONS] PROGRAM -- [ARGS] | --version\n\n", basename(name));
+	fprintf(file, "Usage: %s [OPTIONS] PROGRAM -- [ARGS] | --version\n\n", bname);
 #endif
-	fprintf(file, "Execute a program under the supervision of a valid init process (%s)\n\n", basename(name));
+	fprintf(file, "Execute a program under the supervision of a valid init process (%s)\n\n", bname);
 
 	fprintf(file, "Command line options:\n\n");
 
@@ -261,6 +267,7 @@ void print_usage(char* const name, FILE* const file) {
 	fprintf(file, "  %s: Send signals to the child's process group.\n", KILL_PROCESS_GROUP_GROUP_ENV_VAR);
 
 	fprintf(file, "\n");
+	free(dirc);
 }
 
 void print_license(FILE* const file) {


### PR DESCRIPTION
Musl libc 1.2.5 removed the definition of the basename() function from string.h and only provides it in libgen.h as the POSIX standard defines it.

This change fixes compilation with musl libc 1.2.5.
````
build_dir/target-mips_24kc_musl/tini-0.19.0/src/tini.c:227:36: error: implicit declaration of function 'basename' [-Wimplicit-function-declaration]
  227 |         fprintf(file, "%s (%s)\n", basename(name), TINI_VERSION_STRING);
build_dir/target-mips_24kc_musl/tini-0.19.0/src/tini.c:227:25: error: format '%s' expects argument of type 'char *', but argument 3 has type 'int' [-Werror=format=]
  227 |         fprintf(file, "%s (%s)\n", basename(name), TINI_VERSION_STRING);
      |                        ~^          ~~~~~~~~~~~~~~
      |                         |          |
      |                         char *     int
      |                        %d

````

basename() modifies the input string, copy it first with strdup(), If strdup() returns NULL the code will handle it.