### PR TITLE
Update tini.c

### DIFF
--- a/src/tini.c
+++ b/src/tini.c
@@ -14,6 +14,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <stdbool.h>
+#include <libgen.h>
 
 #include "tiniConfig.h"
 #include "tiniLicense.h"


### PR DESCRIPTION
resolve the compilation errors related to the basename function.