### PR TITLE
Update "ENV key value" format in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ In Docker, you will want to use an entrypoint so you don't have to remember
 to manually invoke Tini:
 
     # Add Tini
-    ENV TINI_VERSION v0.19.0
+    ENV TINI_VERSION=v0.19.0
     ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
     RUN chmod +x /tini
     ENTRYPOINT ["/tini", "--"]


### PR DESCRIPTION
at the moment it using legacy forward and prompt a warning to change to recommended format,

Fixing this will not prompt a warning.

Reference: https://docs.docker.com/reference/build-checks/legacy-key-value-format/