### PR TITLE
chore: allow CMake though to 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required (VERSION 2.8.12...3.10)
 project (tini C)
 
 # Config


### PR DESCRIPTION
This is allows the build with cmake-4.0.0 without deprecation warnings. 

use min...max syntax to allow build with newer cmake. ref: https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html

Fixes #232 
```
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```