### PR TITLE
tini.c: Fix a missing header inclusion

### DIFF
--- a/src/tini.c
+++ b/src/tini.c
@@ -14,6 +14,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <stdbool.h>
+#include <libgen.h>
 
 #include "tiniConfig.h"
 #include "tiniLicense.h"


### PR DESCRIPTION
Fixes:
| .../src/tini.c:227:29: error: call to undeclared function 'basename'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
|   227 |         fprintf(file, "%s (%s)\n", basename(name), TINI_VERSION_STRING);
|       |                                    ^
| .../src/tini.c:227:29: error: format specifies type 'char *' but the argument has type 'int' [-Werror,-Wformat]
|   227 |         fprintf(file, "%s (%s)\n", basename(name), TINI_VERSION_STRING);
|       |                        ~~          ^~~~~~~~~~~~~~
|       |                        %d
| .../src/tini.c:232:73: error: format specifies type 'char *' but the argument has type 'int' [-Werror,-Wformat]
|   232 |         fprintf(file, "Usage: %s [OPTIONS] PROGRAM -- [ARGS] | --version\n\n", basename(name));
|       |                               ~~                                               ^~~~~~~~~~~~~~
|       |                               %d
| .../src/tini.c:234:92: error: format specifies type 'char *' but the argument has type 'int' [-Werror,-Wformat]
|   234 |         fprintf(file, "Execute a program under the supervision of a valid init process (%s)\n\n", basename(name));
|       |                                                                                         ~~        ^~~~~~~~~~~~~~
|       |                                                                                         %d