### PR TITLE
riscv64: add minimal CI (compile-only)

### DIFF
--- a/.github/workflows/riscv64.yml
+++ b/.github/workflows/riscv64.yml
@@ -1,0 +1,36 @@
+name: riscv64 build (QEMU)
+
+on:
+  push: { branches: [ ci/riscv64-qemu ] }   # 只有你这个分支 push 才触发
+  workflow_dispatch:                        # 也支持手动触发
+
+jobs:
+  build-riscv64:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build in riscv64 container (Ubuntu 22.04)
+        uses: uraimo/run-on-arch-action@v2
+        with:
+          arch: riscv64
+          distro: ubuntu22.04
+          run: |
+            set -eux
+            apt-get update
+            apt-get install -y --no-install-recommends build-essential cmake git file ca-certificates
+            export SOURCE_DIR=${{ github.workspace }}
+            export DIST_DIR=${{ github.workspace }}/dist
+            export BUILD_DIR=/tmp/build
+            export ARCH_SUFFIX=riscv64     # 非原生构建必须有后缀
+            chmod +x ci/run_build.sh
+            ./ci/run_build.sh
+            ls -l dist
+            file dist/tini-riscv64
+            sha256sum dist/tini-riscv64
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: tini-riscv64
+          path: dist/tini-riscv64

--- a/.github/workflows/riscv64.yml
+++ b/.github/workflows/riscv64.yml
@@ -26,3 +26,4 @@ jobs:
             chmod +x ci/run_build.sh
             ./ci/run_build.sh
             file dist/tini-riscv64
+Co-authored-by: <nijincheng@iscas.ac.cn>

--- a/.github/workflows/riscv64.yml
+++ b/.github/workflows/riscv64.yml
@@ -1,8 +1,8 @@
 name: riscv64 build (QEMU)
 
 on:
-  push: { branches: [ ci/riscv64-qemu ] }   # 只有你这个分支 push 才触发
-  workflow_dispatch:                        # 也支持手动触发
+  push: { branches: [ ci/riscv64-qemu ] }   
+  workflow_dispatch:                        
 
 jobs:
   build-riscv64:
@@ -22,7 +22,7 @@ jobs:
             export SOURCE_DIR=${{ github.workspace }}
             export DIST_DIR=${{ github.workspace }}/dist
             export BUILD_DIR=/tmp/build
-            export ARCH_SUFFIX=riscv64     # 非原生构建必须有后缀
+            export ARCH_SUFFIX=riscv64     
             chmod +x ci/run_build.sh
             ./ci/run_build.sh
             ls -l dist

--- a/.github/workflows/riscv64.yml
+++ b/.github/workflows/riscv64.yml
@@ -1,15 +1,15 @@
 name: riscv64 build (QEMU)
 
 on:
-  push: { branches: [ ci/riscv64-qemu ] }   
-  workflow_dispatch:                        
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   build-riscv64:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
-
       - name: Build in riscv64 container (Ubuntu 22.04)
         uses: uraimo/run-on-arch-action@v2
         with:
@@ -22,15 +22,7 @@ jobs:
             export SOURCE_DIR=${{ github.workspace }}
             export DIST_DIR=${{ github.workspace }}/dist
             export BUILD_DIR=/tmp/build
-            export ARCH_SUFFIX=riscv64     
+            export ARCH_SUFFIX=riscv64
             chmod +x ci/run_build.sh
             ./ci/run_build.sh
-            ls -l dist
             file dist/tini-riscv64
-            sha256sum dist/tini-riscv64
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: tini-riscv64
-          path: dist/tini-riscv64


### PR DESCRIPTION
This PR adds a minimal riscv64 CI job (compile-only).

- QEMU-based build via uraimo/run-on-arch-action (Ubuntu 22.04)
- Calls project's ci/run_build.sh with ARCH_SUFFIX=riscv64
- No behavior change; just CI coverage to catch regressions on riscv64

Verification (native + container):
- Native build on openEuler riscv64: `tini version 0.19.0 - git.369448a`
- Artifact run under riscv64 container:
    $ docker run --rm --platform=riscv64 -v "$PWD":/work ubuntu:22.04 /work/tini-riscv64 --version
    tini version 0.19.0 - git.2887798
    $ docker run --rm -it --platform=riscv64 -v "$PWD":/work --entrypoint /work/tini-riscv64 ubuntu:22.04 -s -- bash -lc 'echo "bash PID=$$, PPID=$PPID"; cat /proc/1/comm; readlink /proc/1/exe'
    bash PID=7, PPID=1
    tini-riscv64
    /work/tini-riscv64

Context: refs #239 (riscv64 proposal with native build + PID1 experiment).
Happy to switch to cross-compilation, merge into an existing workflow, or adjust triggers per maintainers’ preference.
