### PR TITLE
Add missing stdint.h include to tini.c

### DIFF
--- a/src/tini.c
+++ b/src/tini.c
@@ -15,6 +15,7 @@
 #include <unistd.h>
 #include <stdbool.h>
 #include <libgen.h>
+#include <stdint.h>
 
 #include "tiniConfig.h"
 #include "tiniLicense.h"


### PR DESCRIPTION
`int32_t` is used but `<stdint.h>` is not explicitly included.

N.B. If you are going to merge #247 then you can ignore/close this PR, because `<stdint.h>` was added in there too.